### PR TITLE
Update ownership to PharmaxoScientific

### DIFF
--- a/GitVersionConfig.yaml
+++ b/GitVersionConfig.yaml
@@ -1,0 +1,2 @@
+mode: ContinuousDeployment
+branches: {}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# CR.ViewModels.Core
+# PharmaxoScientific.ViewModels.Core
 
 A package containing .NET interfaces for reading/writing CQRS ViewModels in a generic way.

--- a/src/ViewModels.Core.Tests/InMemoryViewModelRepositoryTests.cs
+++ b/src/ViewModels.Core.Tests/InMemoryViewModelRepositoryTests.cs
@@ -2,10 +2,10 @@
 // Copyright (c) Corsham Science. All rights reserved.
 // </copyright>
 
-namespace CorshamScience.ViewModels.Core.Tests
+namespace PharmaxoScientific.ViewModels.Core.Tests
 {
-    using CorshamScience.ViewModels.Core;
     using NUnit.Framework;
+    using PharmaxoScientific.ViewModels.Core;
 
     /// <inheritdoc />
     [TestFixture]

--- a/src/ViewModels.Core.Tests/TestEntity1.cs
+++ b/src/ViewModels.Core.Tests/TestEntity1.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Corsham Science. All rights reserved.
 // </copyright>
 
-namespace CorshamScience.ViewModels.Core.Tests
+namespace PharmaxoScientific.ViewModels.Core.Tests
 {
     using System;
 

--- a/src/ViewModels.Core.Tests/TestEntity2.cs
+++ b/src/ViewModels.Core.Tests/TestEntity2.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Corsham Science. All rights reserved.
 // </copyright>
 
-namespace CorshamScience.ViewModels.Core.Tests
+namespace PharmaxoScientific.ViewModels.Core.Tests
 {
     using System;
 

--- a/src/ViewModels.Core.Tests/ViewModelRepositoryTestFixture.cs
+++ b/src/ViewModels.Core.Tests/ViewModelRepositoryTestFixture.cs
@@ -2,15 +2,15 @@
 // Copyright (c) Corsham Science. All rights reserved.
 // </copyright>
 
-namespace CorshamScience.ViewModels.Core.Tests
+namespace PharmaxoScientific.ViewModels.Core.Tests
 {
     using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Linq.Expressions;
-    using CorshamScience.ViewModels.Core;
-    using CorshamScience.ViewModels.Core.Exceptions;
     using NUnit.Framework;
+    using PharmaxoScientific.ViewModels.Core;
+    using PharmaxoScientific.ViewModels.Core.Exceptions;
 
     /// <summary>
     /// A Test Fixture for a View Model Repository.

--- a/src/ViewModels.Core.Tests/ViewModels.Core.Tests.csproj
+++ b/src/ViewModels.Core.Tests/ViewModels.Core.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <RootNamespace>CorshamScience.ViewModels.Core.Tests</RootNamespace>
+    <RootNamespace>PharmaxoScientific.ViewModels.Core.Tests</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/ViewModels.Core/Exceptions/DuplicateKeyException.cs
+++ b/src/ViewModels.Core/Exceptions/DuplicateKeyException.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Corsham Science. All rights reserved.
 // </copyright>
 
-namespace CorshamScience.ViewModels.Core.Exceptions
+namespace PharmaxoScientific.ViewModels.Core.Exceptions
 {
     using System;
     using System.Runtime.Serialization;

--- a/src/ViewModels.Core/Exceptions/EntityNotFoundException.cs
+++ b/src/ViewModels.Core/Exceptions/EntityNotFoundException.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Corsham Science. All rights reserved.
 // </copyright>
 
-namespace CorshamScience.ViewModels.Core.Exceptions
+namespace PharmaxoScientific.ViewModels.Core.Exceptions
 {
     using System;
     using System.Runtime.Serialization;

--- a/src/ViewModels.Core/IViewModelReader.cs
+++ b/src/ViewModels.Core/IViewModelReader.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Corsham Science. All rights reserved.
 // </copyright>
 
-namespace CorshamScience.ViewModels.Core
+namespace PharmaxoScientific.ViewModels.Core
 {
     using System;
     using System.Linq;

--- a/src/ViewModels.Core/IViewModelWriter.cs
+++ b/src/ViewModels.Core/IViewModelWriter.cs
@@ -2,11 +2,11 @@
 // Copyright (c) Corsham Science. All rights reserved.
 // </copyright>
 
-namespace CorshamScience.ViewModels.Core
+namespace PharmaxoScientific.ViewModels.Core
 {
     using System;
     using System.Linq.Expressions;
-    using CorshamScience.ViewModels.Core.Exceptions;
+    using PharmaxoScientific.ViewModels.Core.Exceptions;
 
     /// <summary>
     /// An interface that will be extended by any class that allows for writing view models.

--- a/src/ViewModels.Core/InMemoryViewModelRepository.cs
+++ b/src/ViewModels.Core/InMemoryViewModelRepository.cs
@@ -25,7 +25,9 @@ namespace CorshamScience.ViewModels.Core
         /// <summary>
         /// Initializes a new instance of the <see cref="InMemoryViewModelRepository"/> class which reads view models from, and writes them to, a .Net ConcurrentDictionary stored in memory.
         /// </summary>
-        public InMemoryViewModelRepository() => _entityCollections = new ConcurrentDictionary<Type, object>();
+        /// <param name="entityCollections">An optional dictionary to enable preloaded state to be provided.</param>
+        public InMemoryViewModelRepository(ConcurrentDictionary<Type, object> entityCollections = null) =>
+            _entityCollections = entityCollections ?? new ConcurrentDictionary<Type, object>();
 
         /// <summary>
         /// Gets the underlying dictionary which stores all of the entities in the <see cref="InMemoryViewModelRepository"/>.

--- a/src/ViewModels.Core/InMemoryViewModelRepository.cs
+++ b/src/ViewModels.Core/InMemoryViewModelRepository.cs
@@ -2,14 +2,14 @@
 // Copyright (c) Corsham Science. All rights reserved.
 // </copyright>
 
-namespace CorshamScience.ViewModels.Core
+namespace PharmaxoScientific.ViewModels.Core
 {
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
     using System.Linq.Expressions;
-    using CorshamScience.ViewModels.Core.Exceptions;
+    using PharmaxoScientific.ViewModels.Core.Exceptions;
 
     /// <inheritdoc cref="IViewModelReader"/>
     /// <inheritdoc cref="IViewModelWriter"/>

--- a/src/ViewModels.Core/InMemoryViewModelRepository.cs
+++ b/src/ViewModels.Core/InMemoryViewModelRepository.cs
@@ -25,9 +25,7 @@ namespace PharmaxoScientific.ViewModels.Core
         /// <summary>
         /// Initializes a new instance of the <see cref="InMemoryViewModelRepository"/> class which reads view models from, and writes them to, a .Net ConcurrentDictionary stored in memory.
         /// </summary>
-        /// <param name="entityCollections">An optional dictionary to enable preloaded state to be provided.</param>
-        public InMemoryViewModelRepository(ConcurrentDictionary<Type, object> entityCollections = null) =>
-            _entityCollections = entityCollections ?? new ConcurrentDictionary<Type, object>();
+        public InMemoryViewModelRepository() => _entityCollections = new ConcurrentDictionary<Type, object>();
 
         /// <summary>
         /// Gets the underlying dictionary which stores all of the entities in the <see cref="InMemoryViewModelRepository"/>.

--- a/src/ViewModels.Core/ViewModels.Core.csproj
+++ b/src/ViewModels.Core/ViewModels.Core.csproj
@@ -38,6 +38,7 @@
 
   <ItemGroup>
     <None Include="Logo.png">
+      <PackagePath></PackagePath>
       <Pack>True</Pack>
     </None>
   </ItemGroup>

--- a/src/ViewModels.Core/ViewModels.Core.csproj
+++ b/src/ViewModels.Core/ViewModels.Core.csproj
@@ -3,13 +3,13 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyName>CorshamScience.ViewModels.Core</AssemblyName>
-    <RootNamespace>CorshamScience.ViewModels.Core</RootNamespace>
-    <PackageId>CorshamScience.ViewModels.Core</PackageId>
-    <Authors>Corsham Science</Authors>
-    <Company>Corsham Science</Company>
+    <AssemblyName>PharmaxoScientific.ViewModels.Core</AssemblyName>
+    <RootNamespace>PharmaxoScientific.ViewModels.Core</RootNamespace>
+    <PackageId>PharmaxoScientific.ViewModels.Core</PackageId>
+    <Authors>Pharmaxo Scientific</Authors>
+    <Company>Pharmaxo Scientific</Company>
     <Product>CorshamScience.ViewModels</Product>
-    <Copyright>Corsham Science 2019</Copyright>
+    <Copyright>Pharmaxo Scientific 2025</Copyright>
     <Description>A package containing .NET interfaces for reading/writing CQRS ViewModels in a generic way.</Description>
     <PackageProjectUrl>https://github.com/qphl/ViewModels.Core</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/qphl/ViewModels.Core/master/logo.png</PackageIconUrl>
@@ -21,13 +21,13 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>bin\Debug\netstandard2.0\CorshamScience.ViewModels.Core.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\netstandard2.0\PharmaxoScientific.ViewModels.Core.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
-    <DocumentationFile>bin\Release\netstandard2.0\CorshamScience.ViewModels.Core.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\netstandard2.0\PharmaxoScientific.ViewModels.Core.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -38,7 +38,6 @@
 
   <ItemGroup>
     <None Include="Logo.png">
-      <PackagePath></PackagePath>
       <Pack>True</Pack>
     </None>
   </ItemGroup>


### PR DESCRIPTION
# Update ownership to `PharmaxoScientific`

This pull request updates references to "Corsham Science" to be "Pharmaxo Scientific"

Note that this branch initially intended to allow a `ConcurrentDictionary` to be injected into the `ViewModelRepository`, however this is now longer the intent.